### PR TITLE
WrenSec Builds - Phase #1 (for wrensec-rest)

### DIFF
--- a/.wren-deploy.rc
+++ b/.wren-deploy.rc
@@ -1,0 +1,14 @@
+export MAVEN_PACKAGE="forgerock-rest"
+export BINTRAY_PACKAGE="wrensec-rest"
+export JFROG_PACKAGE="org/forgerock/commons/forgerock-rest"
+
+package_accept_release_tag() {
+  local tag_name="${1}"
+
+  if [ "${tag_name}" == "2.0.0-Xpress2" ]; then
+    echo "Skipping 2.0.0-Xpress2 since it does not look official."
+    return -1
+  else
+    return 0
+  fi
+}

--- a/forgerock-rest-docbook/pom.xml
+++ b/forgerock-rest-docbook/pom.xml
@@ -13,6 +13,7 @@
   information: "Portions Copyrighted [year] [name of copyright owner]".
 
   Copyright 2015 ForgeRock AS.
+  Portions Copyright 2017 Wren Security.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
@@ -24,6 +25,6 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>forgerock-rest-docbook</artifactId>
-    <name>Common ForgeRock REST DocBook Sources</name>
-    <description>Common ForgeRock REST DocBook XML Sources</description>
+    <name>Wren Security Common REST DocBook Sources</name>
+    <description>Wren Security Common REST DocBook XML Sources</description>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -41,15 +41,15 @@
     </scm>
     <distributionManagement>
         <snapshotRepository>
-            <id>bintray-wrensecurity-releases</id>
+            <id>wrensecurity-snapshots</id>
             <name>Wren Security Snapshot Repository</name>
-            <url>${forgerockDistMgmtSnapshotsUrl}/wrensec-rest/;publish=1</url>
+            <url>${forgerockDistMgmtSnapshotsUrl}</url>
         </snapshotRepository>
 
         <repository>
-            <id>bintray-wrensecurity-snapshots</id>
+            <id>wrensecurity-releases</id>
             <name>Wren Security Release Repository</name>
-            <url>${forgerockDistMgmtReleasesUrl}/wrensec-rest/;publish=1</url>
+            <url>${forgerockDistMgmtReleasesUrl}</url>
         </repository>
     </distributionManagement>
     <properties>
@@ -120,10 +120,11 @@
         </plugins>
     </reporting>
     <repositories>
+    <!-- Needed to retrieve parent POM -->
         <repository>
-            <id>bintray-wrensecurity-releases</id>
+            <id>wrensecurity-releases</id>
             <name>Wren Security Release Repository</name>
-            <url>http://dl.bintray.com/wrensecurity/releases</url>
+            <url>https://wrensecurity.jfrog.io/wrensecurity/releases</url>
 
             <snapshots>
                 <enabled>false</enabled>
@@ -131,20 +132,6 @@
 
             <releases>
                 <enabled>true</enabled>
-            </releases>
-        </repository>
-
-        <repository>
-            <id>bintray-wrensecurity-snapshots</id>
-            <name>Wren Security Snapshot Repository</name>
-            <url>http://dl.bintray.com/wrensecurity/snapshots</url>
-
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-
-            <releases>
-                <enabled>false</enabled>
             </releases>
         </repository>
     </repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,7 @@
   information: "Portions Copyrighted [year] [name of copyright owner]".
 
   Copyright 2012-2015 ForgeRock AS.
+  Portions Copyright 2017 Wren Security.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -25,29 +26,31 @@
     <artifactId>forgerock-rest</artifactId>
     <version>4.0.3</version>
     <packaging>pom</packaging>
-    <name>ForgeRock REST libraries</name>
-    <description>Common resource-oriented libraries used by ForgeRock projects</description>
-    <url>http://commons.forgerock.org/forgerock-rest</url>
+    <name>Wren Security REST libraries</name>
+    <description>Common resource-oriented libraries used by Wren Security forks of ForgeRock
+        projects</description>
+    <url>http://wrensecurity.org/</url>
     <issueManagement>
-        <system>Jira</system>
-        <url>https://bugster.forgerock.org/jira/browse/CREST</url>
+        <system>GitHub Issues</system>
+        <url>https://github.com/WrenSecurity/wrensec-rest/issues</url>
     </issueManagement>
     <scm>
-        <connection>scm:git:ssh://git@stash.forgerock.org:7999/commons/forgerock-rest.git</connection>
-        <developerConnection>scm:git:ssh://git@stash.forgerock.org:7999/commons/forgerock-rest.git</developerConnection>
-        <url>http://stash.forgerock.org/projects/COMMONS/repos/forgerock-rest/browse</url>
-      <tag>4.0.3</tag>
-  </scm>
-    <ciManagement>
-        <system>jenkins</system>
-        <url>https://ci.forgerock.org/view/Commons/job/Commons%20-%20Rest%20-%20postcommit/</url>
-    </ciManagement>
+        <url>https://github.com/WrenSecurity/wrensec-rest</url>
+        <connection>scm:git:git://github.com/WrenSecurity/wrensec-rest.git</connection>
+        <developerConnection>scm:git:git@github.com:WrenSecurity/wrensec-rest.git</developerConnection>
+    </scm>
     <distributionManagement>
-        <site>
-            <id>forgerock.org</id>
-            <name>ForgeRock Community</name>
-            <url>scp://forgerock.org/var/www/vhosts/commons.forgerock.org/httpdocs/forgerock-rest</url>
-        </site>
+        <snapshotRepository>
+            <id>bintray-wrensecurity-releases</id>
+            <name>Wren Security Snapshot Repository</name>
+            <url>${forgerockDistMgmtSnapshotsUrl}/wrensec-rest/;publish=1</url>
+        </snapshotRepository>
+
+        <repository>
+            <id>bintray-wrensecurity-snapshots</id>
+            <name>Wren Security Release Repository</name>
+            <url>${forgerockDistMgmtReleasesUrl}/wrensec-rest/;publish=1</url>
+        </repository>
     </distributionManagement>
     <properties>
         <i18nFrameworkVersion>1.4.1</i18nFrameworkVersion>
@@ -118,17 +121,28 @@
     </reporting>
     <repositories>
         <repository>
-            <id>forgerock-staging-repository</id>
-            <name>ForgeRock Release Repository</name>
-            <url>http://maven.forgerock.org/repo/releases</url>
+            <id>bintray-wrensecurity-releases</id>
+            <name>Wren Security Release Repository</name>
+            <url>http://dl.bintray.com/wrensecurity/releases</url>
+
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>
+
+            <releases>
+                <enabled>true</enabled>
+            </releases>
         </repository>
+
         <repository>
-            <id>forgerock-snapshots-repository</id>
-            <name>ForgeRock Snapshot Repository</name>
-            <url>http://maven.forgerock.org/repo/snapshots</url>
+            <id>bintray-wrensecurity-snapshots</id>
+            <name>Wren Security Snapshot Repository</name>
+            <url>http://dl.bintray.com/wrensecurity/snapshots</url>
+
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+
             <releases>
                 <enabled>false</enabled>
             </releases>


### PR DESCRIPTION
- modifies the POMs to build using Wren's repos.
- updates branding to call this Wren Security Common REST instead of ForgeRock Common REST.
- adds [Wren Deploy](https://github.com/WrenSecurity/wrensec-deploy-tool) RC file.
- the `sustaining/*` branches have already been updated with similar changes.